### PR TITLE
return config and explicitly index section and param

### DIFF
--- a/ROOTFS/usr/bin/waggle-network-watchdog
+++ b/ROOTFS/usr/bin/waggle-network-watchdog
@@ -27,21 +27,11 @@ def seconds_since(start):
 
 def must_read_config_file(filename):
     config = configparser.ConfigParser()
-
+    # configparser.read only returns a list of successfully read files,
+    # so we wrap the failure case as an exception.
     if not config.read(filename):
-        logging.warning(f"could not read config file {filename}")
-        return None
-
-    try:
-        section = config["watchdog"]
-    except KeyError:
-        logging.warning("config error: must have section [watchdog]")
-        return None
-
-    try:
-        return section["ssh_ok_file"]
-    except KeyError:
-        return None
+        raise RuntimeError(f"could not read config file {filename}")
+    return config
 
 def ssh_connection_ok():
     try:
@@ -80,7 +70,9 @@ def reboot_os():
     # aggressively but safely reboot the system
     subprocess.run(["systemctl", "--force", "reboot"])
 
-ssh_ok_file = must_read_config_file("/etc/waggle/config.ini")
+config = must_read_config_file("/etc/waggle/config.ini")
+ssh_ok_file = config["watchdog"]["ssh_ok_file"]
+
 last_connection_time = time_now()
 
 # Recovery actions table [time (s), recovery function]

--- a/ROOTFS/usr/bin/waggle-network-watchdog
+++ b/ROOTFS/usr/bin/waggle-network-watchdog
@@ -25,13 +25,21 @@ def time_now():
 def seconds_since(start):
     return time.monotonic() - start
 
-def must_read_config_file(filename):
+
+def must_read_config_section(filename, section):
     config = configparser.ConfigParser()
-    # configparser.read only returns a list of successfully read files,
-    # so we wrap the failure case as an exception.
+
     if not config.read(filename):
-        raise RuntimeError(f"could not read config file {filename}")
-    return config
+        logging.warning(f"could not read config file {filename}")
+        return {}
+
+    try:
+        return dict(config[section])
+    except Exception:
+        logging.warning("could not read config section [%s]", section)
+
+    return {}
+
 
 def ssh_connection_ok():
     try:
@@ -70,8 +78,9 @@ def reboot_os():
     # aggressively but safely reboot the system
     subprocess.run(["systemctl", "--force", "reboot"])
 
-config = must_read_config_file("/etc/waggle/config.ini")
-ssh_ok_file = config["watchdog"]["ssh_ok_file"]
+
+config = must_read_config_section("/etc/waggle/config.ini", "watchdog")
+ssh_ok_file = config.get("ssh_ok_file", None)
 
 last_connection_time = time_now()
 
@@ -85,8 +94,10 @@ recovery_actions = [
     (900, restart_network_services),
 ]
 
+# sort in increasing order of threshold so that our linear
+# search finds the "earliest" available action
 recovery_actions.sort()
-available_actions=recovery_actions.copy()
+available_actions = recovery_actions.copy()
 
 while True:
     update_systemd_watchdog()
@@ -94,13 +105,13 @@ while True:
     if ssh_connection_ok():
         logging.info("connection ok")
 
-        if ssh_ok_file:
+        if ssh_ok_file is not None:
             Path(ssh_ok_file).touch()
         else:
             logging.info("not setting flag for wagman-watchdog")
         
         last_connection_time = time_now()
-        available_actions=recovery_actions.copy()
+        available_actions = recovery_actions.copy()
     else:
         logging.warning(
             "no connection for %ss", int(seconds_since(last_connection_time))


### PR DESCRIPTION
I found the ssh_ok_file = must_read_config_file step a little confusing. In my opinion as an external reader, it would be more clear to just return the config data and then explicitly index the section and param you want.
