### PR TITLE
[SAGE-618] Require health check to pass multiple times to make more robust

### DIFF
--- a/ROOTFS/usr/bin/waggle-network-watchdog
+++ b/ROOTFS/usr/bin/waggle-network-watchdog
@@ -10,6 +10,7 @@ from typing import NamedTuple
 
 class WatchdogConfig(NamedTuple):
     ssh_ok_file: str
+    check_seconds: float
     check_successive_passes: int
     check_successive_seconds: float
 
@@ -34,6 +35,7 @@ def read_watchdog_config(filename, section="watchdog"):
 
     return WatchdogConfig(
         ssh_ok_file=d.get("ssh_ok_file", None),
+        check_seconds=float(d.get("check_seconds", 15.0)),
         check_successive_passes=int(d.get("check_successive_passes", 3)),
         check_successive_seconds=float(d.get("check_successive_seconds", 5.0)),
     )
@@ -150,7 +152,7 @@ def main():
                 available_actions.remove((thresh, action))
                 break
 
-        time.sleep(15)
+        time.sleep(config.check_seconds)
 
 
 if __name__ == "__main__":

--- a/ROOTFS/usr/bin/waggle-network-watchdog
+++ b/ROOTFS/usr/bin/waggle-network-watchdog
@@ -5,28 +5,16 @@ import time
 import logging
 from glob import glob
 import configparser
-
-logging.basicConfig(level=logging.INFO)
-
-last_connection_time = 0
+from typing import NamedTuple
 
 
-def update_systemd_watchdog():
-    try:
-        subprocess.check_call(["systemd-notify", "WATCHDOG=1"])
-    except subprocess.CalledProcessError:
-        logging.warning("skipping reset of systemd watchdog")
+class WatchdogConfig(NamedTuple):
+    ssh_ok_file: str
+    check_successive_passes: int
+    check_successive_seconds: float
 
 
-def time_now():
-    return time.monotonic()
-
-
-def seconds_since(start):
-    return time.monotonic() - start
-
-
-def must_read_config_section(filename, section):
+def read_config_section_dict(filename, section):
     config = configparser.ConfigParser()
 
     if not config.read(filename):
@@ -41,6 +29,31 @@ def must_read_config_section(filename, section):
     return {}
 
 
+def read_watchdog_config(filename, section="watchdog"):
+    d = read_config_section_dict(filename, section)
+
+    return WatchdogConfig(
+        ssh_ok_file=d.get("ssh_ok_file", None),
+        check_successive_passes=int(d.get("check_successive_passes", 3)),
+        check_successive_seconds=float(d.get("check_successive_seconds", 5.0)),
+    )
+
+
+def update_systemd_watchdog():
+    try:
+        subprocess.check_call(["systemd-notify", "WATCHDOG=1"])
+    except Exception:
+        logging.warning("skipping reset of systemd watchdog")
+
+
+def time_now():
+    return time.monotonic()
+
+
+def seconds_since(start):
+    return time.monotonic() - start
+
+
 def ssh_connection_ok():
     try:
         return (
@@ -49,6 +62,14 @@ def ssh_connection_ok():
         )
     except Exception:
         return False
+
+
+def require_successive_passes(check_func, successive_passes, successive_seconds):
+    for _ in range(successive_passes):
+        if not check_func():
+            return False
+        time.sleep(successive_seconds)
+    return True
 
 
 # NOTE Revisit how much of the network stack we should restart. For now, I want to cover all
@@ -79,49 +100,58 @@ def reboot_os():
     subprocess.run(["systemctl", "--force", "reboot"])
 
 
-config = must_read_config_section("/etc/waggle/config.ini", "watchdog")
-ssh_ok_file = config.get("ssh_ok_file", None)
-
-last_connection_time = time_now()
-
 # Recovery actions table [time (s), recovery function]
 # restart networking stack after 15, 20 and 25 of no beehive connectivity
 # reboot after 30 mins of no beehive connectivity
-recovery_actions = [
+#
+# NOTE We sort in increasing order of threshold so that our linear
+# search finds the "earliest" available action
+recovery_actions = sorted([
     (1800, reboot_os),
     (1500, restart_network_services),
     (1200, restart_network_services),
     (900, restart_network_services),
-]
+])
 
-# sort in increasing order of threshold so that our linear
-# search finds the "earliest" available action
-recovery_actions.sort()
-available_actions = recovery_actions.copy()
 
-while True:
-    update_systemd_watchdog()
+def main():
+    logging.basicConfig(level=logging.INFO)
 
-    if ssh_connection_ok():
-        logging.info("connection ok")
+    config = read_watchdog_config("/etc/waggle/config.ini")
 
-        if ssh_ok_file is not None:
-            Path(ssh_ok_file).touch()
+    last_connection_time = time_now()
+    available_actions = recovery_actions.copy()
+
+    while True:
+        update_systemd_watchdog()
+
+        logging.info("checking connection")
+        if require_successive_passes(ssh_connection_ok,
+                                     config.check_successive_passes,
+                                     config.check_successive_seconds):
+            logging.info("connection ok")
+
+            if config.ssh_ok_file is not None:
+                Path(config.ssh_ok_file).touch()
+            else:
+                logging.info("not setting flag for wagman-watchdog")
+            
+            last_connection_time = time_now()
+            available_actions = recovery_actions.copy()
         else:
-            logging.info("not setting flag for wagman-watchdog")
-        
-        last_connection_time = time_now()
-        available_actions = recovery_actions.copy()
-    else:
-        logging.warning(
-            "no connection for %ss", int(seconds_since(last_connection_time))
-        )
+            logging.warning(
+                "no connection for %ss", int(seconds_since(last_connection_time))
+            )
 
-    for thresh, action in available_actions:
-        if seconds_since(last_connection_time) >= thresh:
-            logging.warning("executing %ds recovery action", thresh)
-            action()
-            available_actions.remove((thresh, action))
-            break
+        for thresh, action in available_actions:
+            if seconds_since(last_connection_time) >= thresh:
+                logging.warning("executing %ds recovery action", thresh)
+                action()
+                available_actions.remove((thresh, action))
+                break
 
-    time.sleep(15)
+        time.sleep(15)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* Using `require_successive_passes` for main check to make more robust.
* Factored out config and added support for:
  * `check_successive_passes` - number of passes required (default: 3)
  * `check_successive_seconds` - seconds between each check (default: 5.0)
* Move main loop into `main` function to avoid any accidental variable scope creep.