### PR TITLE
SAGE-752: use server:port from reverse-tunnel config

### DIFF
--- a/ROOTFS/usr/bin/waggle-network-watchdog
+++ b/ROOTFS/usr/bin/waggle-network-watchdog
@@ -3,6 +3,7 @@ from pathlib import Path
 import subprocess
 import time
 import logging
+import socket
 from glob import glob
 import configparser
 from typing import NamedTuple
@@ -13,6 +14,11 @@ class WatchdogConfig(NamedTuple):
     check_seconds: float
     check_successive_passes: int
     check_successive_seconds: float
+
+
+class ReverseTunnelConfig(NamedTuple):
+    beekeeper_server: str
+    beekeeper_port: str
 
 
 def read_config_section_dict(filename, section):
@@ -41,6 +47,15 @@ def read_watchdog_config(filename, section="watchdog"):
     )
 
 
+def read_reverse_tunnel_config(filename, section="reverse-tunnel"):
+    d = read_config_section_dict(filename, section)
+
+    return ReverseTunnelConfig(
+        beekeeper_server=d.get("host", None),
+        beekeeper_port=d.get("port", None),
+    )
+
+
 def update_systemd_watchdog():
     try:
         subprocess.check_call(["systemd-notify", "WATCHDOG=1"])
@@ -56,19 +71,26 @@ def seconds_since(start):
     return time.monotonic() - start
 
 
-def ssh_connection_ok():
+def ssh_connection_ok(server, port):
     try:
+
+        # do a lookup of the ip for the server
+        server_addr = f"{socket.gethostbyname(server)}:{port}"
+        logging.debug(f"checking for ssh connection to [{server_addr}]")
+
         return (
-            "beehive:20022"
-            in subprocess.check_output(["ss", "-tr", "state", "established"]).decode()
+            server_addr
+            in subprocess.check_output(["ss", "-t", "state", "established"]).decode()
         )
     except Exception:
         return False
 
 
-def require_successive_passes(check_func, successive_passes, successive_seconds):
+def require_successive_passes(
+    check_func, server, port, successive_passes, successive_seconds
+):
     for _ in range(successive_passes):
-        if not check_func():
+        if not check_func(server, port):
             return False
         time.sleep(successive_seconds)
     return True
@@ -91,7 +113,7 @@ def restart_network_services():
             "restart",
             "NetworkManager",
             "ModemManager",
-            "waggle-reverse-tunnel",
+            "waggle-bk-reverse-tunnel",
         ]
     )
 
@@ -108,18 +130,21 @@ def reboot_os():
 #
 # NOTE We sort in increasing order of threshold so that our linear
 # search finds the "earliest" available action
-recovery_actions = sorted([
-    (1800, reboot_os),
-    (1500, restart_network_services),
-    (1200, restart_network_services),
-    (900, restart_network_services),
-])
+recovery_actions = sorted(
+    [
+        (1800, reboot_os),
+        (1500, restart_network_services),
+        (1200, restart_network_services),
+        (900, restart_network_services),
+    ]
+)
 
 
 def main():
     logging.basicConfig(level=logging.INFO)
 
-    config = read_watchdog_config("/etc/waggle/config.ini")
+    wd_config = read_watchdog_config("/etc/waggle/config.ini")
+    rssh_config = read_reverse_tunnel_config("/etc/waggle/config.ini")
 
     last_connection_time = time_now()
     available_actions = recovery_actions.copy()
@@ -127,17 +152,23 @@ def main():
     while True:
         update_systemd_watchdog()
 
-        logging.info("checking connection")
-        if require_successive_passes(ssh_connection_ok,
-                                     config.check_successive_passes,
-                                     config.check_successive_seconds):
+        logging.info(
+            f"checking connection [{rssh_config.beekeeper_server}:{rssh_config.beekeeper_port}]"
+        )
+        if require_successive_passes(
+            ssh_connection_ok,
+            rssh_config.beekeeper_server,
+            rssh_config.beekeeper_port,
+            wd_config.check_successive_passes,
+            wd_config.check_successive_seconds,
+        ):
             logging.info("connection ok")
 
-            if config.ssh_ok_file is not None:
-                Path(config.ssh_ok_file).touch()
+            if wd_config.ssh_ok_file is not None:
+                Path(wd_config.ssh_ok_file).touch()
             else:
                 logging.info("not setting flag for wagman-watchdog")
-            
+
             last_connection_time = time_now()
             available_actions = recovery_actions.copy()
         else:
@@ -152,7 +183,7 @@ def main():
                 available_actions.remove((thresh, action))
                 break
 
-        time.sleep(config.check_seconds)
+        time.sleep(wd_config.check_seconds)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The reverse tunnel server and port number are not read from the
system config and used to construct the pattern to search for within
the "ssh connection lookup" ('ss'). The pattern is constructed of
the host's IP address and port number ('<ip>:<port>') to eliminate the
need for 'ss' to perform any network resolution.