### PR TITLE
SAGE-1285: remove the '--force' in the reboot/poweroff to allow servi…

### DIFF
--- a/ROOTFS/usr/bin/waggle_network_watchdog.py
+++ b/ROOTFS/usr/bin/waggle_network_watchdog.py
@@ -204,14 +204,14 @@ def restart_network_services(nwwd_config):
 
 def reboot_os():
     logging.warning("rebooting the system")
-    # aggressively but safely reboot the system
-    subprocess.run(["systemctl", "--force", "reboot"])
+    # execute normal reboot to allow shutdown services to clean-up
+    subprocess.run(["systemctl", "reboot"])
 
 
 def shutdown_os():
     logging.warning("shutting down the system")
-    # aggressively but safely shutdown the system
-    subprocess.run(["systemctl", "--force", "poweroff"])
+    # execute normal poweroff to allow shutdown services to clean-up
+    subprocess.run(["systemctl", "poweroff"])
 
 
 # NOTE(sean) I'm trying to better isolate the full behavior of actions into self


### PR DESCRIPTION
…ce shutdowns

Since the time this '--force' option was introduced alot of improvements
have been made in the way the WSN reboots and powers off. Most notably, k3s
now properly shuts down and removes the ~2 minute timeout that occurs.
Additionally, the waggle-agent-power service needs to run through
its shutdown sequence to properly turn off compute units (i.e. RPi)
and accessories (i.e. PSU ports). And lastly, even if the reboot/shutdown
hangs there is a shutdown watchdog that exists that will eventually
reboot / poweroff the system after ~30 minutes.

So, it seems safe to remove the '--force' and allow the WSN to run through
it's normal reboot / poweroff sequence.