### PR TITLE
SAGE-1414: add "pass window" support

### DIFF
--- a/ROOTFS/etc/waggle/nw/config.ini
+++ b/ROOTFS/etc/waggle/nw/config.ini
@@ -1,26 +1,27 @@
 [all]
-check_seconds = 30.0
-check_successive_passes = 3
-check_successive_seconds = 5.0
+health_check_period = 30.0
+health_check_test_runs = 3
+health_check_test_runs_period = 5.0
+health_check_pass_threshold = 600.0
 rssh_addrs = [ ('beehive', 'beehive', 20022) ]
 network_services = [ "NetworkManager", "ModemManager", "waggle-reverse-tunnel", "waggle-bk-reverse-tunnel" ]
 sd_card_storage_loc = /media/scratch
 
 [network-reboot]
 reset_start = 900
-reset_interval = 300
+reset_interval = 900
 current_reset_file = /etc/waggle/nw/network_reset_count
 
 # Set the soft-reboot reset_start to a non-multiple of network-reboot reset_interval and
-#  atleast check_seconds seconds "away" to prevent network restart occuring at the same time as reboot
+#  atleast health_check_period seconds less to prevent network restart occuring at the same time as reboot
 [soft-reboot]
-max_resets = 3
-reset_start = 3660
+max_resets = 2
+reset_start = 3400
 current_reset_file = /etc/waggle/nw/soft_reset_count
 
-# Ensure the hard-reboot reset_start is atleast check_seconds seconds "past" the
+# Ensure the hard-reboot reset_start is atleast health_check_period seconds "past" the
 #  soft-reboot reset_start to prevent reboot vs shutdown race-condition
 [hard-reboot]
 max_resets = 2
-reset_start = 3720
+reset_start = 3500
 current_reset_file = /etc/waggle/nw/hard_reset_count

--- a/ROOTFS/usr/bin/test_waggle_network_watchdog.py
+++ b/ROOTFS/usr/bin/test_waggle_network_watchdog.py
@@ -1,17 +1,33 @@
 #!/usr/bin/env python3
+import argparse
 import logging
+import random
 import sys
 
 
 def main():
     import waggle_network_watchdog
 
+    parser = argparse.ArgumentParser(description="Network Watchdog Test")
+    parser.add_argument(
+        "-l", dest="loop", type=int, help="Current loop used for modifying pass rate"
+    )
+    parser.add_argument("-n", dest="loop_max", type=int, help="Max loop")
+    args = parser.parse_args()
+
     logging.basicConfig(level=logging.INFO)
+
+    den = args.loop_max * 2
+    logging.info("Loop %d (fail rate: %f)", args.loop, (args.loop / den))
 
     current_time = 0.0
 
     def fake_time():
         return current_time
+
+    # simulate an increasing failure rate, based on loop
+    def fake_health_check():
+        return not (random.uniform(0, 1) < (args.loop / den))
 
     def fake_reboot_os():
         logging.warning("ACTION reboot os")
@@ -28,7 +44,7 @@ def main():
 
     watchdog = waggle_network_watchdog.Watchdog(
         time_func=fake_time,
-        health_check=lambda: False,
+        health_check=fake_health_check,
         health_check_passed=real_watchdog.health_check_passed,
         health_check_failed=real_watchdog.health_check_failed,
         recovery_actions=real_watchdog.recovery_actions,
@@ -40,7 +56,7 @@ def main():
     waggle_network_watchdog.log_scoreboard(nwwd_config)
 
     for _ in range(10000):
-        current_time += nwwd_config.check_seconds
+        current_time += nwwd_config.health_check_period
         watchdog.update()
 
 

--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,8 @@ getvalue() {
     fi
 }
 
-for _ in $(seq 20); do
+loops=20
+for i in $(seq $loops); do
     echo STATE current_media $(getvalue /tmp/current-slot 0)
     echo STATE mmc_network_reset_count $(getvalue /etc/waggle/nw/network_reset_count 0)
     echo STATE mmc_soft_reset_count $(getvalue /etc/waggle/nw/soft_reset_count 0)
@@ -18,6 +19,6 @@ for _ in $(seq 20); do
     echo STATE sd_network_reset_count $(getvalue /media/scratch/etc/waggle/nw/network_reset_count 0)
     echo STATE sd_soft_reset_count $(getvalue /media/scratch/etc/waggle/nw/soft_reset_count 0)
     echo STATE sd_hard_reset_count $(getvalue /media/scratch/etc/waggle/nw/hard_reset_count 0)
-    /usr/bin/test_waggle_network_watchdog.py
+    /usr/bin/test_waggle_network_watchdog.py -l $i -n $loops
 done
 '


### PR DESCRIPTION
Before this change a single connection pass reset the recovery score-board.
This presented problems with "blippy" internet that required a hard-reboot.
Because the internet test would pass 1 time during an entire boot, the
recovery score-board would be reset and a hard-reboot would never be
attempted.

This change requires that a window of consecutive passes occur in-order
to reset the recovery score-board.  This way a single passing connection
test or very short passing window does not cause the recovery process
to be interrupted.

Other notable changes:
- removed 1 soft reboot
- reduced frequency of network restarts (which tend not to help)
- added 10 minute "pass window" before score-board reset
- updated unit-test to have passing and failure connection checks