### PR TITLE
SAGE-1414: add pass/fail buffer system

### DIFF
--- a/ROOTFS/etc/waggle/nw/config.ini
+++ b/ROOTFS/etc/waggle/nw/config.ini
@@ -1,26 +1,33 @@
 [all]
-check_seconds = 30.0
-check_successive_passes = 3
-check_successive_seconds = 5.0
+health_check_period = 30.0
+# score range [0-5: failing, 6-14: buffer, 15-20: passing]
+health_check_max_score = 20
+health_check_pass_score_perc = 0.75
+health_check_fail_score_perc = 0.25
+# speed to increase score
+health_check_good_acc = 1
+# speed to decrease score
+health_check_fail_acc = -1
+
 rssh_addrs = [ ('beehive', 'beehive', 20022) ]
 network_services = [ "NetworkManager", "ModemManager", "waggle-reverse-tunnel", "waggle-bk-reverse-tunnel" ]
 sd_card_storage_loc = /media/scratch
 
 [network-reboot]
 reset_start = 900
-reset_interval = 300
+reset_interval = 900
 current_reset_file = /etc/waggle/nw/network_reset_count
 
 # Set the soft-reboot reset_start to a non-multiple of network-reboot reset_interval and
-#  atleast check_seconds seconds "away" to prevent network restart occuring at the same time as reboot
+#  atleast health_check_period seconds less to prevent network restart occuring at the same time as reboot
 [soft-reboot]
-max_resets = 3
-reset_start = 3660
+max_resets = 2
+reset_start = 3400
 current_reset_file = /etc/waggle/nw/soft_reset_count
 
-# Ensure the hard-reboot reset_start is atleast check_seconds seconds "past" the
+# Ensure the hard-reboot reset_start is atleast health_check_period seconds "past" the
 #  soft-reboot reset_start to prevent reboot vs shutdown race-condition
 [hard-reboot]
 max_resets = 2
-reset_start = 3720
+reset_start = 3500
 current_reset_file = /etc/waggle/nw/hard_reset_count

--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,8 @@ getvalue() {
     fi
 }
 
-for _ in $(seq 20); do
+loops=20
+for i in $(seq $loops); do
     echo STATE current_media $(getvalue /tmp/current-slot 0)
     echo STATE mmc_network_reset_count $(getvalue /etc/waggle/nw/network_reset_count 0)
     echo STATE mmc_soft_reset_count $(getvalue /etc/waggle/nw/soft_reset_count 0)
@@ -18,6 +19,6 @@ for _ in $(seq 20); do
     echo STATE sd_network_reset_count $(getvalue /media/scratch/etc/waggle/nw/network_reset_count 0)
     echo STATE sd_soft_reset_count $(getvalue /media/scratch/etc/waggle/nw/soft_reset_count 0)
     echo STATE sd_hard_reset_count $(getvalue /media/scratch/etc/waggle/nw/hard_reset_count 0)
-    /usr/bin/test_waggle_network_watchdog.py
+    /usr/bin/test_waggle_network_watchdog.py -l $i -n $loops
 done
 '


### PR DESCRIPTION
Before this change a single connection pass reset the recovery score-board.
This presented problems with "blippy" internet that required a hard-reboot.
Because the internet test would pass 1 time during an entire boot, the
recovery score-board would be reset and a hard-reboot would never be
attempted.

This change adds a buffer requiring a pass/fail majority before a
connection is considered good/bad again. In order for a connection
to be considered good, there needs to be a long majority of passing
connection tests to push the "connection confidence" high enough
for a connection to be considered passing. The inverse applies for
detection of a bad connection, driving the "connection confidence" low.

Other notable changes:
- removed 1 soft reboot
- reduced frequency of network restarts (which tend not to help)
- added confidence buffer
- updated unit-test to have passing and failure connection checks