### PR TITLE
SAGE-1414: add pass/fail history system

### DIFF
--- a/ROOTFS/etc/waggle/nw/config.ini
+++ b/ROOTFS/etc/waggle/nw/config.ini
@@ -1,11 +1,13 @@
 [all]
 health_check_period = 30.0
 # history to compute connection health
-health_check_history = 600.0
+## 15 minutes of total history
+health_check_history = 900.0
 # percentage "pass" of health history indicating healthy connection
-health_check_healthy_perc = 0.70
-# percentage "pass" of health history indicating recovery needed
-health_check_recovery_perc = 0.50
+## 10 minutes in the last 15 minutes (66%) to indicates "pass"
+health_check_healthy_perc = 0.66
+# percentage "pass" of health history indicating recovery counter should start
+health_check_recovery_perc = 0.66
 
 rssh_addrs = [ ('beehive', 'beehive', 20022) ]
 network_services = [ "NetworkManager", "ModemManager", "waggle-reverse-tunnel", "waggle-bk-reverse-tunnel" ]

--- a/ROOTFS/etc/waggle/nw/config.ini
+++ b/ROOTFS/etc/waggle/nw/config.ini
@@ -1,26 +1,31 @@
 [all]
-check_seconds = 30.0
-check_successive_passes = 3
-check_successive_seconds = 5.0
+health_check_period = 30.0
+# history to compute connection health
+health_check_history = 600.0
+# percentage "pass" of health history indicating healthy connection
+health_check_healthy_perc = 0.70
+# percentage "pass" of health history indicating recovery needed
+health_check_recovery_perc = 0.50
+
 rssh_addrs = [ ('beehive', 'beehive', 20022) ]
 network_services = [ "NetworkManager", "ModemManager", "waggle-reverse-tunnel", "waggle-bk-reverse-tunnel" ]
 sd_card_storage_loc = /media/scratch
 
 [network-reboot]
 reset_start = 900
-reset_interval = 300
+reset_interval = 900
 current_reset_file = /etc/waggle/nw/network_reset_count
 
 # Set the soft-reboot reset_start to a non-multiple of network-reboot reset_interval and
-#  atleast check_seconds seconds "away" to prevent network restart occuring at the same time as reboot
+#  atleast health_check_period seconds less to prevent network restart occuring at the same time as reboot
 [soft-reboot]
-max_resets = 3
-reset_start = 3660
+max_resets = 2
+reset_start = 3400
 current_reset_file = /etc/waggle/nw/soft_reset_count
 
-# Ensure the hard-reboot reset_start is atleast check_seconds seconds "past" the
+# Ensure the hard-reboot reset_start is atleast health_check_period seconds "past" the
 #  soft-reboot reset_start to prevent reboot vs shutdown race-condition
 [hard-reboot]
 max_resets = 2
-reset_start = 3720
+reset_start = 3500
 current_reset_file = /etc/waggle/nw/hard_reset_count

--- a/ROOTFS/usr/bin/test_waggle_network_watchdog.py
+++ b/ROOTFS/usr/bin/test_waggle_network_watchdog.py
@@ -17,7 +17,7 @@ def main():
 
     logging.basicConfig(level=logging.INFO)
 
-    den = args.loop_max * 1.5
+    den = args.loop_max
     logging.info("Loop %d (fail rate: %f)", args.loop, (args.loop / den))
 
     current_time = 0.0

--- a/ROOTFS/usr/bin/waggle_network_watchdog.py
+++ b/ROOTFS/usr/bin/waggle_network_watchdog.py
@@ -6,6 +6,7 @@ import logging
 import socket
 import subprocess
 import time
+from collections import deque
 from glob import glob
 from pathlib import Path
 from typing import Callable, NamedTuple
@@ -22,9 +23,32 @@ class Action(NamedTuple):
     func: Callable
 
 
+class HealthHistoryConfig(NamedTuple):
+    health_check_history_count: int
+    health_check_healthy_perc: float
+    health_check_recovery_perc: float
+
+
+class HealthHistory:
+    def __init__(self, count: int):
+        self.history = deque([False] * count, maxlen=count)
+        # assume low score on init
+        self.percentage = 0.0
+
+    def add(self, n):
+        self.history.append(n)
+        self.percentage = self.history.count(True) / self.history.maxlen
+
+
 class Watchdog:
     def __init__(
-        self, time_func, recovery_actions, health_check, health_check_passed, health_check_failed
+        self,
+        time_func,
+        recovery_actions,
+        health_check,
+        health_check_passed,
+        health_check_failed,
+        health_score_config,
     ):
         self.time_func = time_func
         self.recovery_actions = [Action(thresh, func) for thresh, func in recovery_actions]
@@ -34,6 +58,8 @@ class Watchdog:
         self.health_check = health_check
         self.health_check_passed = health_check_passed
         self.health_check_failed = health_check_failed
+        self.health_score_config = health_score_config
+        self.health_score = HealthHistory(health_score_config.health_check_history_count)
 
         self.last_connection_time = self.time_func()
 
@@ -43,22 +69,40 @@ class Watchdog:
         elapsed = health_check_finish_time - self.last_connection_time
 
         if health_check_ok:
+            self.health_score.add(True)
+            logging.info(
+                "connection health check passed (%.2f%% >= %.2f%%)",
+                100 * self.health_score.percentage,
+                100 * self.health_score_config.health_check_healthy_perc,
+            )
+        else:
+            self.health_score.add(False)
+            logging.info(
+                "connection health check failed (%.2f%% >= %.2f%%)",
+                100 * self.health_score.percentage,
+                100 * self.health_score_config.health_check_recovery_perc,
+            )
+
+        # if above the "healthy" percentage, indicate healthy
+        if self.health_score.percentage >= self.health_score_config.health_check_healthy_perc:
             self.health_check_passed(elapsed)
             self.last_connection_time = health_check_finish_time
             self.called_actions.clear()
-            return
 
-        self.health_check_failed(elapsed)
-
-        # dispatch all activated recovery actions
-        for action in self.recovery_actions:
-            if elapsed < action.thresh:
+        # if below the "not healthy" percentage, enter recovery counter
+        if self.health_score.percentage < self.health_score_config.health_check_recovery_perc:
+            self.health_check_failed(elapsed)
+            # dispatch all activated recovery actions
+            for action in self.recovery_actions:
+                if elapsed < action.thresh:
+                    break
+                if action in self.called_actions:
+                    continue
+                self.called_actions.add(action)
+                logging.debug("calling action %s", action)
+                # call a single action and break, allowing time for recovery
+                action.func()
                 break
-            if action in self.called_actions:
-                continue
-            self.called_actions.add(action)
-            logging.debug("calling action %s", action)
-            action.func()
 
 
 class WatchdogConfig(NamedTuple):
@@ -66,9 +110,10 @@ class WatchdogConfig(NamedTuple):
 
 
 class NetworkWatchdogConfig(NamedTuple):
-    check_seconds: float
-    check_successive_passes: int
-    check_successive_seconds: float
+    health_check_period: float
+    health_check_history: float
+    health_check_healthy_perc: float
+    health_check_recovery_perc: float
     current_media: int
     rssh_addrs: list
     network_services: list
@@ -140,9 +185,10 @@ def read_network_watchdog_config(filename):
         hard_reset_file=sd_card_storage_loc + hard_reset_settings.get("current_reset_file", None),
         rssh_addrs=list(ast.literal_eval(all_settings.get("rssh_addrs", None))),
         network_services=json.loads(all_settings.get("network_services", None)),
-        check_seconds=float(all_settings.get("check_seconds", 15.0)),
-        check_successive_passes=int(all_settings.get("check_successive_passes", 3)),
-        check_successive_seconds=float(all_settings.get("check_successive_seconds", 5.0)),
+        health_check_period=float(all_settings.get("health_check_period", 15.0)),
+        health_check_history=float(all_settings.get("health_check_history", 600.0)),
+        health_check_healthy_perc=float(all_settings.get("health_check_healthy_perc", 0.7)),
+        health_check_recovery_perc=float(all_settings.get("health_check_recovery_perc", 0.3)),
     )
 
 
@@ -180,14 +226,6 @@ def ssh_connection_ok(server, port):
         return server_addr in subprocess.check_output(["ss", "-t", "state", "established"]).decode()
     except Exception:
         return False
-
-
-def require_successive_passes(check_func, server, port, successive_passes, successive_seconds):
-    for _ in range(successive_passes):
-        if not check_func(server, port):
-            return False
-        time.sleep(successive_seconds)
-    return True
 
 
 def fix_modem_port_settings():
@@ -284,7 +322,10 @@ def build_rec_actions(nwwd_config):
     ):
         recovery_actions.append([t, reset_network_action])
 
-    return sorted(recovery_actions, key=lambda x: x[0])
+    recovery_actions = sorted(recovery_actions, key=lambda x: x[0])
+    logging.info(f"Recovery schedule: {recovery_actions}")
+
+    return recovery_actions
 
 
 def read_resets_safe(reset_file):
@@ -362,12 +403,9 @@ def build_watchdog(nwwd_config_path=NW_WATCHDOG_CONFIG_PATH, rssh_config_path=SY
         # check the built in config(s)
         logging.info("checking connections to any of %s", nwwd_config.rssh_addrs)
         for alias, server, port in nwwd_config.rssh_addrs:
-            curServerHealth = require_successive_passes(
-                ssh_connection_ok,
+            curServerHealth = ssh_connection_ok(
                 server,
                 port,
-                nwwd_config.check_successive_passes,
-                nwwd_config.check_successive_seconds,
             )
 
             health = health or curServerHealth
@@ -379,12 +417,9 @@ def build_watchdog(nwwd_config_path=NW_WATCHDOG_CONFIG_PATH, rssh_config_path=SY
         logging.info(
             f"checking connections to 'beekeeper' [{rssh_config.beekeeper_server}, {rssh_config.beekeeper_port}]"
         )
-        curServerHealth = require_successive_passes(
-            ssh_connection_ok,
+        curServerHealth = ssh_connection_ok(
             rssh_config.beekeeper_server,
             rssh_config.beekeeper_port,
-            nwwd_config.check_successive_passes,
-            nwwd_config.check_successive_seconds,
         )
 
         health = health or curServerHealth
@@ -395,15 +430,31 @@ def build_watchdog(nwwd_config_path=NW_WATCHDOG_CONFIG_PATH, rssh_config_path=SY
         return health
 
     def health_check_passed(timer):
-        logging.info("connection ok")
+        logging.info("connection ok (last healthy connection: %ss ago)", timer)
         update_reset_file(nwwd_config.hard_reset_file, 0)
         update_reset_file(nwwd_config.soft_reset_file, 0)
         update_reset_file(nwwd_config.network_reset_file, 0)
 
     def health_check_failed(timer):
-        logging.warning("no connection for %ss", timer)
+        logging.warning("no connection for %ss (last healthy connection)", timer)
 
     recovery_actions = build_rec_actions(nwwd_config)
+
+    health_check_history_count = int(
+        nwwd_config.health_check_history / nwwd_config.health_check_period
+    )
+    logging.info(
+        "Health history count: %d (history: %fs, check_period: %fs)",
+        health_check_history_count,
+        nwwd_config.health_check_history,
+        nwwd_config.health_check_period,
+    )
+
+    health_score_config = HealthHistoryConfig(
+        health_check_history_count=health_check_history_count,
+        health_check_healthy_perc=nwwd_config.health_check_healthy_perc,
+        health_check_recovery_perc=nwwd_config.health_check_recovery_perc,
+    )
 
     return Watchdog(
         time_func=time.monotonic,
@@ -411,6 +462,7 @@ def build_watchdog(nwwd_config_path=NW_WATCHDOG_CONFIG_PATH, rssh_config_path=SY
         health_check_passed=health_check_passed,
         health_check_failed=health_check_failed,
         recovery_actions=recovery_actions,
+        health_score_config=health_score_config,
     )
 
 
@@ -441,7 +493,7 @@ def main():
         if wd_config.nwwd_ok_file is not None:
             Path(wd_config.nwwd_ok_file).touch()
 
-        time.sleep(nwwd_config.check_seconds)
+        time.sleep(nwwd_config.health_check_period)
 
 
 if __name__ == "__main__":

--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,8 @@ getvalue() {
     fi
 }
 
-for _ in $(seq 20); do
+loops=20
+for i in $(seq $loops); do
     echo STATE current_media $(getvalue /tmp/current-slot 0)
     echo STATE mmc_network_reset_count $(getvalue /etc/waggle/nw/network_reset_count 0)
     echo STATE mmc_soft_reset_count $(getvalue /etc/waggle/nw/soft_reset_count 0)
@@ -18,6 +19,6 @@ for _ in $(seq 20); do
     echo STATE sd_network_reset_count $(getvalue /media/scratch/etc/waggle/nw/network_reset_count 0)
     echo STATE sd_soft_reset_count $(getvalue /media/scratch/etc/waggle/nw/soft_reset_count 0)
     echo STATE sd_hard_reset_count $(getvalue /media/scratch/etc/waggle/nw/hard_reset_count 0)
-    /usr/bin/test_waggle_network_watchdog.py
+    /usr/bin/test_waggle_network_watchdog.py -l $i -n $loops
 done
 '


### PR DESCRIPTION
Before this change a single connection pass reset the recovery score-board.
This presented problems with "blippy" internet that required a hard-reboot.
Because the internet test would pass 1 time during an entire boot, the
recovery score-board would be reset and a hard-reboot would never be
attempted.

This change adds a connection history buffer requiring a pass/fail
majority before a connection is considered good/bad again. The last X
number of test results are averaged to "connection confidence"
percentage. When that percentage exceeds a "healthy" threshold the
connection is considered healthy and the scoreboard is reset. When
the percentage falls below a threshold, the connection is considered
unheathly, and recovery actions are initiated.

Other notable changes:
- remove the 3x "successive" tests per run (replaced by this sytem)
- removed 1 soft reboot
- reduced frequency of network restarts (which tend not to help)
- added connection history buffer
- updated unit-test to have passing and failure connection checks